### PR TITLE
ci: upload VectorDB sync errors as artifact and add run summary

### DIFF
--- a/.github/workflows/vector_sync.yml
+++ b/.github/workflows/vector_sync.yml
@@ -63,3 +63,28 @@ jobs:
           fi
           echo "[info] Sync range: $BASE..$HEAD"
           python codechat/vectordb_sync.py --from-commit "$BASE" --to-commit "$HEAD" --repo-root .
+
+      - name: Error summary
+        if: always()
+        shell: bash
+        run: |
+          if [ -f codechat/.vector_sync_errors.jsonl ]; then
+            {
+              echo "## Vector Sync Errors";
+              echo;
+              echo '```jsonl';
+              tail -n 200 codechat/.vector_sync_errors.jsonl;
+              echo '```';
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "No errors file present."
+          fi
+
+      - name: Upload VectorDB Sync errors
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: vector-sync-errors
+          path: codechat/.vector_sync_errors.jsonl
+          if-no-files-found: ignore
+          retention-days: 7


### PR DESCRIPTION
﻿This adds observability for VectorDB Sync runs without changing sync logic or submodule handling.

- Error summary step (always): appends the last 200 lines of `codechat/.vector_sync_errors.jsonl` to the job summary (if present).
- Artifact upload (always): attaches `codechat/.vector_sync_errors.jsonl` as `vector-sync-errors` with 7-day retention.
- Harmless when the file isn’t present (`if-no-files-found: ignore`).

How to use
- After a run, open the workflow job → Summary to quickly scan errors.
- Download the `vector-sync-errors` artifact for full details and local replay.
