### PR TITLE
Fix Vercel install failure — bump pnpm 9.12.3 → 10.13.1

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,5 @@
 {
-  "installCommand": "corepack prepare pnpm@9.12.3 --activate && pnpm --prefix chat install",
+  "installCommand": "corepack use pnpm@10.13.1 && pnpm --prefix chat install",
   "buildCommand": "pnpm --prefix chat build",
   "outputDirectory": "chat/.next",
   "framework": "nextjs"


### PR DESCRIPTION
ERR_INVALID_THIS ("Value of 'this' must be of type URLSearchParams") was breaking 
  every npm registry metadata fetch during Vercel's install step, causing the 
  webroot build to fail immediately.

  Ruled out: lockfile (valid, committed), Node version (fails identically on 
  20/22/24), submodules (initialize fine). This is a known pnpm bug tied to 
  pnpm 9.12.3 specifically in Vercel's build network.

  Fix: bump pinned pnpm version from 9.12.3 to 10.13.1 in installCommand.
  Verified locally — installs cleanly against the existing lockfile with zero 
  lockfile drift (same 909 packages resolved).